### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/plugins/com.netxforge.oss2.releng.root/pom.xml
+++ b/plugins/com.netxforge.oss2.releng.root/pom.xml
@@ -774,7 +774,7 @@
     <activemqVersion>5.6.0</activemqVersion>
     <commonsBeanutilsVersion>1.8.3</commonsBeanutilsVersion>
     <commonsCodecVersion>1.7</commonsCodecVersion>
-    <commonsCollectionsVersion>3.2.1</commonsCollectionsVersion>
+    <commonsCollectionsVersion>3.2.2</commonsCollectionsVersion>
     <commonsIoVersion>2.0.1</commonsIoVersion>
     <commonsLangVersion>2.6</commonsLangVersion>
     <commonsLoggingVersion>1.1.1</commonsLoggingVersion>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
